### PR TITLE
schema: XmlBeans requires log4j so add it as runtime dependency

### DIFF
--- a/allowed-licenses.json
+++ b/allowed-licenses.json
@@ -8,6 +8,9 @@
     },
     {
       "moduleLicense": "The Apache Software License, Version 2.0"
+    },
+    {
+      "moduleLicense": "Apache-2.0"
     }
   ]
 }

--- a/schema/build.gradle.kts
+++ b/schema/build.gradle.kts
@@ -13,4 +13,7 @@ sourceSets {
 
 dependencies {
     implementation("org.apache.xmlbeans:xmlbeans:5.2.1")
+
+    runtimeOnly(platform("org.apache.logging.log4j:log4j-bom:2.24.1"))
+    runtimeOnly("org.apache.logging.log4j:log4j-core")
 }


### PR DESCRIPTION
Otherwise, we get an ERROR in stdout: "ERROR Log4j2 could not find a logging implementation. Please add log4j-core to the classpath. Using SimpleLogger to log to the console..."