### PR TITLE
build: produce only one license report, CI publishes license reports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,19 @@ jobs:
       uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
     - name: Build with Gradle Wrapper
-      run: ./gradlew build
+      run: ./gradlew build check
+
+    - name: Upload license reports
+      # Try to upload report even if previous step fails
+      if: '!cancelled()'
+      continue-on-error: true
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: error
+        name: license-check-report
+        path: |
+          ./build/reports/dependency-license/dependencies-without-allowed-license.json
+          ./build/reports/dependency-license/project-licenses-for-check-license-task.json
 
     - name: Prepare lib artifacts
       run: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,2 +1,18 @@
+plugins {
+    id("com.github.jk1.dependency-license-report") version "2.9"
+}
+
 group = "eu.efti.datatools"
 version = "0.0.1-SNAPSHOT"
+
+licenseReport {
+    allowedLicensesFile = rootProject.file("allowed-licenses.json")
+}
+
+tasks.checkLicense {
+    inputs.file("$rootDir/allowed-licenses.json")
+}
+
+tasks.create("check") {
+    dependsOn(tasks.checkLicense)
+}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,5 +11,4 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin:$kotlinVersion")
-    implementation("com.github.jk1:gradle-license-report:2.9")
 }

--- a/buildSrc/src/main/kotlin/data-tools.kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/data-tools.kotlin-conventions.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
-    id("com.github.jk1.dependency-license-report")
 }
 
 repositories {
@@ -45,16 +44,4 @@ tasks.register<Test>("updateTestExpectations") {
 
     // Always run task even if it has successfully completed earlier
     outputs.upToDateWhen { false }
-}
-
-licenseReport {
-    allowedLicensesFile = rootProject.file("allowed-licenses.json")
-}
-
-tasks.checkLicense {
-    inputs.file("$rootDir/allowed-licenses.json")
-}
-
-tasks.check {
-    dependsOn(tasks.checkLicense)
 }


### PR DESCRIPTION
You can inspect the report at build artifacts of the workflow run. For example: https://github.com/EFTI4EU/efti-data-tools/actions/runs/12235057823?pr=12