### PR TITLE
populate: fix/add support for deleting nodes in the populated doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ The following examples use gradle to simplify testing. Note how the xpath expres
 ./gradlew app:run --args="populate -x identifier -w -s 42 -t 'consignment/deliveryEvent/actualOccurrenceDateTime:=202412312359+0000'"
 ```
 
-##### Unset value by overwriting with empty value
+##### Delete node
 
 ```shell
-./gradlew app:run --args="populate -x identifier -w -s 42 -t 'consignment/deliveryEvent/actualOccurrenceDateTime:='"
+./gradlew app:run --args="populate -x identifier -w -s 42 -d 'consignment/deliveryEvent/actualOccurrenceDateTime'"
 ```
 
 ##### Set multiple identifiers to same value

--- a/populate/src/main/kotlin/eu/efti/datatools/populate/EftiXPathDocumentManipulator.kt
+++ b/populate/src/main/kotlin/eu/efti/datatools/populate/EftiXPathDocumentManipulator.kt
@@ -7,8 +7,18 @@ import javax.xml.xpath.XPathConstants
 import javax.xml.xpath.XPathExpression
 import javax.xml.xpath.XPathFactory
 
-object EftiTextContentWriter {
+object EftiXPathDocumentManipulator {
     private val xpathFactory = XPathFactory.newInstance()
+
+    fun deleteNode(doc: Document, xpath: String) {
+        val compiled = compileXpath(xpath)
+        deleteNode(doc, compiled)
+    }
+
+    fun deleteNode(doc: Document, xpath: XPathExpression) {
+        val nodes = xpath.evaluate(doc, XPathConstants.NODESET) as NodeList
+        nodes.asIterable().forEach { node -> node.parentNode.removeChild(node) }
+    }
 
     fun setTextContent(doc: Document, xpath: String, value: String) {
         val compiled = compileXpath(xpath)


### PR DESCRIPTION
Overriding node text content with empty string produced invalid documents. Add support for a "delete node" override that deletes the whole node from the document.